### PR TITLE
Change bumpers coordinate system of SDH fingers

### DIFF
--- a/cob_description/ros/urdf/sdh_v0/sdh.gazebo.xacro
+++ b/cob_description/ros/urdf/sdh_v0/sdh.gazebo.xacro
@@ -24,6 +24,7 @@
 				<controller:gazebo_ros_bumper name="${name}_finger_12_gazebo_ros_bumper_controller" plugin="libgazebo_ros_bumper.so">
 					<alwaysOn>true</alwaysOn>
 					<updateRate>100.0</updateRate>
+					<frameName>${name}_finger_12_link</frameName>
 					<bumperTopicName>${name}_finger_12_bumper</bumperTopicName>
 					<interface:bumper name="${name}_finger_12_bumper_iface" />
 				</controller:gazebo_ros_bumper>
@@ -40,6 +41,7 @@
 				<controller:gazebo_ros_bumper name="${name}_finger_13_gazebo_ros_bumper_controller" plugin="libgazebo_ros_bumper.so">
 					<alwaysOn>true</alwaysOn>
 					<updateRate>100.0</updateRate>
+					<frameName>${name}_finger_13_link</frameName>
 					<bumperTopicName>${name}_finger_13_bumper</bumperTopicName>
 					<interface:bumper name="${name}_finger_13_bumper_iface" />
 				</controller:gazebo_ros_bumper>
@@ -60,6 +62,7 @@
 				<controller:gazebo_ros_bumper name="${name}_finger_22_gazebo_ros_bumper_controller" plugin="libgazebo_ros_bumper.so">
 					<alwaysOn>true</alwaysOn>
 					<updateRate>100.0</updateRate>
+					<frameName>${name}_finger_22_link</frameName>
 					<bumperTopicName>${name}_finger_22_bumper</bumperTopicName>
 					<interface:bumper name="${name}_finger_22_bumper_iface" />
 				</controller:gazebo_ros_bumper>
@@ -76,6 +79,7 @@
 				<controller:gazebo_ros_bumper name="${name}_finger_23_gazebo_ros_bumper_controller" plugin="libgazebo_ros_bumper.so">
 					<alwaysOn>true</alwaysOn>
 					<updateRate>100.0</updateRate>
+					<frameName>${name}_finger_23_link</frameName>
 					<bumperTopicName>${name}_finger_23_bumper</bumperTopicName>
 					<interface:bumper name="${name}_finger_23_bumper_iface" />
 				</controller:gazebo_ros_bumper>
@@ -96,6 +100,7 @@
 				<controller:gazebo_ros_bumper name="${name}_thumb_2_gazebo_ros_bumper_controller" plugin="libgazebo_ros_bumper.so">
 					<alwaysOn>true</alwaysOn>
 					<updateRate>100.0</updateRate>
+					<frameName>${name}_thumb_2_link</frameName>
 					<bumperTopicName>${name}_thumb_2_bumper</bumperTopicName>
 					<interface:bumper name="${name}_thumb_2_bumper_iface" />
 				</controller:gazebo_ros_bumper>
@@ -112,6 +117,7 @@
 				<controller:gazebo_ros_bumper name="${name}_thumb_3_gazebo_ros_bumper_controller" plugin="libgazebo_ros_bumper.so">
 					<alwaysOn>true</alwaysOn>
 					<updateRate>100.0</updateRate>
+					<frameName>${name}_thumb_3_link</frameName>
 					<bumperTopicName>${name}_thumb_3_bumper</bumperTopicName>
 					<interface:bumper name="${name}_thumb_3_bumper_iface" />
 				</controller:gazebo_ros_bumper>


### PR DESCRIPTION
In simulation, the bumpers that are attached to the fingers provide their data in the "world" coordinate frame. To simulate the tactile sensors it is better to get the data in the local coordinate system of the fingers.

This commit changes the coordinate systems accordingly.
