### PR TITLE
gazebo needs a new link for the topic

### DIFF
--- a/cob_description/urdf/sensors/sick_s300_laser.gazebo.xacro
+++ b/cob_description/urdf/sensors/sick_s300_laser.gazebo.xacro
@@ -2,7 +2,7 @@
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
 
   <xacro:macro name="sick_s300_laser_gazebo_v0" params="name ros_topic update_rate min_angle max_angle">
-    <gazebo reference="${name}_link">
+    <gazebo reference="${name}_gazebo_topic_link">
       <sensor name="${name}" type="ray">
         <always_on>true</always_on>
         <update_rate>${update_rate}</update_rate>

--- a/cob_description/urdf/sensors/sick_s300_laser.urdf.xacro
+++ b/cob_description/urdf/sensors/sick_s300_laser.urdf.xacro
@@ -34,6 +34,14 @@
       </collision>
     </link>
     
+    <joint name="${name}_gazebo_topic_joint" type="fixed">
+      <origin xyz="0.05 0 0" rpy="0 0 0"/>
+      <parent link="${name}_link"/>
+      <child link="${name}_gazebo_topic_link"/>
+    </joint>
+    
+    <link name="${name}_gazebo_topic_link"/>
+
     <!-- gazebo extensions -->
     <xacro:sick_s300_laser_gazebo_v0 name="${name}" ros_topic="${ros_topic}" update_rate="${update_rate}" min_angle="${min_angle}" max_angle="${max_angle}" />
   </xacro:macro>


### PR DESCRIPTION
 if we use the origin of the scanner (the center), the topic detects only the collision model
