### PR TITLE
[Indigo] use VelocityJointInterface hardware interfaces for simulation of all bases

### DIFF
--- a/cob_description/urdf/cob3_base/base.transmission.xacro
+++ b/cob_description/urdf/cob3_base/base.transmission.xacro
@@ -7,7 +7,7 @@
     <transmission name="${parent}_${suffix}_wheel_trans">
       <type>transmission_interface/SimpleTransmission</type>
       <joint name="${parent}_${suffix}_wheel_joint" >
-        <hardwareInterface>EffortJointInterface</hardwareInterface>
+        <hardwareInterface>VelocityJointInterface</hardwareInterface>
       </joint>
       <actuator name="${parent}_${suffix}_wheel_motor">
         <mechanicalReduction>${reflect * 624/35 * 80/18}</mechanicalReduction>
@@ -22,7 +22,7 @@
     <transmission name="${suffix}_rotation_trans">
       <type>transmission_interface/SimpleTransmission</type>
       <joint name="${suffix}_rotation_joint" >
-        <hardwareInterface>EffortJointInterface</hardwareInterface>
+        <hardwareInterface>VelocityJointInterface</hardwareInterface>
       </joint>
       <actuator name="${suffix}_rotation_motor" >
         <mechanicalReduction>${-1 * 624/35 * 80/18}</mechanicalReduction>

--- a/cob_description/urdf/cob4_base/base.transmission.xacro
+++ b/cob_description/urdf/cob4_base/base.transmission.xacro
@@ -6,7 +6,7 @@
     <transmission name="${parent}_${suffix}_wheel_trans">
       <type>transmission_interface/SimpleTransmission</type>
       <joint name="${parent}_${suffix}_wheel_joint" >
-        <hardwareInterface>EffortJointInterface</hardwareInterface>
+        <hardwareInterface>VelocityJointInterface</hardwareInterface>
       </joint>
       <actuator name="${parent}_${suffix}_wheel_motor">
         <mechanicalReduction>${reflect * 624/35 * 80/18}</mechanicalReduction>
@@ -19,7 +19,7 @@
     <transmission name="${suffix}_rotation_trans">
       <type>transmission_interface/SimpleTransmission</type>
       <joint name="${suffix}_rotation_joint" >
-        <hardwareInterface>EffortJointInterface</hardwareInterface>
+        <hardwareInterface>VelocityJointInterface</hardwareInterface>
       </joint>
       <actuator name="${suffix}_rotation_motor" >
         <mechanicalReduction>${-1 * 624/35 * 80/18}</mechanicalReduction>

--- a/desire_description/urdf/base_desire/base.transmission.xacro
+++ b/desire_description/urdf/base_desire/base.transmission.xacro
@@ -6,7 +6,7 @@
     <transmission name="desire_wheel_transmission_v0">
       <type>transmission_interface/SimpleTransmission</type>
       <joint name="${parent}_${suffix}_wheel_joint">
-        <hardwareInterface>EffortJointInterface</hardwareInterface>
+        <hardwareInterface>VelocityJointInterface</hardwareInterface>
       </joint>      
       <actuator name="${parent}_${suffix}_wheel_motor">
         <mechanicalReduction>${reflect * 624/35 * 80/18}</mechanicalReduction>
@@ -19,7 +19,7 @@
     <transmission name="desire_caster_transmission_v0">
       <type>transmission_interface/SimpleTransmission</type>
       <joint name="${suffix}_rotation_joint">
-        <hardwareInterface>EffortJointInterface</hardwareInterface>
+        <hardwareInterface>VelocityJointInterface</hardwareInterface>
       </joint>      
       <actuator name="${suffix}_rotation_motor">
         <mechanicalReduction>${-1 * 624/35 * 80/18}</mechanicalReduction>

--- a/raw_description/urdf/base_long/base.transmission.xacro
+++ b/raw_description/urdf/base_long/base.transmission.xacro
@@ -6,7 +6,7 @@
     <transmission name="cob_wheel_transmission">
       <type>transmission_interface/SimpleTransmission</type>
       <joint name="${parent}_${suffix}_wheel_joint">      
-        <hardwareInterface>EffortJointInterface</hardwareInterface>
+        <hardwareInterface>VelocityJointInterface</hardwareInterface>
       </joint>
       <actuator name="${parent}_${suffix}_wheel_motor">
         <mechanicalReduction>${reflect * 624/35 * 80/18}</mechanicalReduction>
@@ -19,7 +19,7 @@
     <transmission name="cob_caster_transmission">
       <type>transmission_interface/SimpleTransmission</type>
       <joint name="${suffix}_rotation_joint">
-        <hardwareInterface>EffortJointInterface</hardwareInterface>
+        <hardwareInterface>VelocityJointInterface</hardwareInterface>
       </joint>      
       <actuator name="${suffix}_rotation_motor">
         <mechanicalReduction>${-1 * 624/35 * 80/18}</mechanicalReduction>

--- a/raw_description/urdf/base_short/base.transmission.xacro
+++ b/raw_description/urdf/base_short/base.transmission.xacro
@@ -6,7 +6,7 @@
     <transmission name="${parent}_${suffix}_wheel_trans">
       <type>transmission_interface/SimpleTransmission</type>
       <joint name="${parent}_${suffix}_wheel_joint">
-        <hardwareInterface>EffortJointInterface</hardwareInterface>
+        <hardwareInterface>VelocityJointInterface</hardwareInterface>
       </joint>
       <actuator name="${parent}_${suffix}_wheel_motor">
         <mechanicalReduction>${reflect * 624/35 * 80/18}</mechanicalReduction>
@@ -19,7 +19,7 @@
     <transmission name="${suffix}_rotation_trans">
       <type>transmission_interface/SimpleTransmission</type>
       <joint name="${suffix}_rotation_joint" >
-        <hardwareInterface>EffortJointInterface</hardwareInterface>
+        <hardwareInterface>VelocityJointInterface</hardwareInterface>
       </joint>
       <actuator name="${suffix}_rotation_motor" >
         <mechanicalReduction>${-1 * 624/35 * 80/18}</mechanicalReduction>


### PR DESCRIPTION
Merge together with [cob_robots#234](https://github.com/ipa320/cob_robots/pull/234)

This PR improves simulated Odometry with a factor of about 10...especially when a "Zero-Twist" is sent, i.e. base should not move at all.

@ipa-mig and others from the Nav-Team please review (do you have students working with simulation?)
