### PR TITLE
cleanup cob_srvs

### DIFF
--- a/cob_srvs/CMakeLists.txt
+++ b/cob_srvs/CMakeLists.txt
@@ -1,25 +1,18 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(cob_srvs)
 
-find_package(catkin REQUIRED COMPONENTS std_msgs trajectory_msgs geometry_msgs message_generation)
+find_package(catkin REQUIRED COMPONENTS std_msgs message_generation)
 
 add_service_files(FILES
   Trigger.srv
-  SetMaxVel.srv
-  SetInt.srv
   SetFloat.srv
   SetString.srv
-  SetOperationMode.srv
-  SetJointTrajectory.srv
-  SetJointStiffness.srv
-  SetDefaultVel.srv
-  GetPoseStampedTransformed.srv
 )
 
 generate_messages(
-  DEPENDENCIES geometry_msgs std_msgs trajectory_msgs
+  DEPENDENCIES std_msgs
 )
 
 catkin_package(
-    CATKIN_DEPENDS message_runtime std_msgs trajectory_msgs geometry_msgs
+    CATKIN_DEPENDS std_msgs message_runtime
 )

--- a/cob_srvs/package.xml
+++ b/cob_srvs/package.xml
@@ -13,13 +13,9 @@
   <author email="fmw@ipa.fhg.de">Florian Weisshardt</author>
 
   <buildtool_depend>catkin</buildtool_depend>
-  <build_depend>message_generation</build_depend>
   <build_depend>std_msgs</build_depend>
-  <build_depend>trajectory_msgs</build_depend>
-  <build_depend>geometry_msgs</build_depend>
-  <run_depend>message_runtime</run_depend>
+  <build_depend>message_generation</build_depend>
   <run_depend>std_msgs</run_depend>
-  <run_depend>trajectory_msgs</run_depend>
-  <run_depend>geometry_msgs</run_depend>
+  <run_depend>message_runtime</run_depend>
 
 </package>

--- a/cob_srvs/srv/GetPoseStampedTransformed.srv
+++ b/cob_srvs/srv/GetPoseStampedTransformed.srv
@@ -1,8 +1,0 @@
-geometry_msgs/PoseStamped target
-geometry_msgs/PoseStamped origin
-geometry_msgs/Quaternion  orientation_override
-string root_name
-string tip_name
----
-bool success
-geometry_msgs/PoseStamped result

--- a/cob_srvs/srv/SetDefaultVel.srv
+++ b/cob_srvs/srv/SetDefaultVel.srv
@@ -1,4 +1,0 @@
-float32 default_vel
----
-std_msgs/Bool success
-std_msgs/String error_message

--- a/cob_srvs/srv/SetFloat.srv
+++ b/cob_srvs/srv/SetFloat.srv
@@ -1,4 +1,4 @@
 float32 data
 ---
 bool success
-std_msgs/String errorMessage
+string message

--- a/cob_srvs/srv/SetInt.srv
+++ b/cob_srvs/srv/SetInt.srv
@@ -1,4 +1,0 @@
-int32 data
----
-bool success
-std_msgs/String errorMessage

--- a/cob_srvs/srv/SetJointStiffness.srv
+++ b/cob_srvs/srv/SetJointStiffness.srv
@@ -1,4 +1,0 @@
-float32[] joint_stiffness
----
-std_msgs/Bool success
-std_msgs/String error_message

--- a/cob_srvs/srv/SetJointTrajectory.srv
+++ b/cob_srvs/srv/SetJointTrajectory.srv
@@ -1,4 +1,0 @@
-trajectory_msgs/JointTrajectory trajectory
----
-int64 success
-std_msgs/String errorMessage

--- a/cob_srvs/srv/SetMaxVel.srv
+++ b/cob_srvs/srv/SetMaxVel.srv
@@ -1,4 +1,0 @@
-float32 max_vel
----
-bool success
-std_msgs/String errorMessage

--- a/cob_srvs/srv/SetOperationMode.srv
+++ b/cob_srvs/srv/SetOperationMode.srv
@@ -1,4 +1,0 @@
-std_msgs/String operation_mode
----
-std_msgs/Bool success
-std_msgs/String error_message

--- a/cob_srvs/srv/SetString.srv
+++ b/cob_srvs/srv/SetString.srv
@@ -1,4 +1,4 @@
 string data
 ---
 bool success
-std_msgs/String errorMessage
+string message


### PR DESCRIPTION
I started with a cleanup of cob_srvs removing unused services and used the more generic SetFloat/SetString services. Also I removed std_msgs from those services

used in:
- https://github.com/ipa320/schunk_modular_robotics/pull/134
- https://github.com/ipa320/cob_control/pull/30
- https://github.com/ipa320/cob_driver/pull/216
