### PR TITLE
fixed copy paste error for base_short laser mounting position

### DIFF
--- a/raw_description/urdf/base_short/base.urdf.xacro
+++ b/raw_description/urdf/base_short/base.urdf.xacro
@@ -122,7 +122,7 @@
 
     <!-- base laser rear -->
     <xacro:sick_s300_laser_v0 name="${name}_laser_rear" parent="${name}" ros_topic="scan_rear_raw" update_rate="10" min_angle="-2.3562" max_angle="2.3562" >
-      <origin xyz="${laser_front_x} ${laser_front_y} ${laser_front_z}" rpy="${laser_front_roll} ${laser_front_pitch} ${laser_front_yaw}" />
+      <origin xyz="${laser_rear_x} ${laser_rear_y} ${laser_rear_z}" rpy="${laser_rear_roll} ${laser_rear_pitch} ${laser_rear_yaw}" />
     </xacro:sick_s300_laser_v0>
 
     <!-- cam3d -->


### PR DESCRIPTION
there is still a calibration error, look hat the laserscans on the image. red=scan_front_raw magenta=scan_rear_raw
![image](https://cloud.githubusercontent.com/assets/483721/10141311/20ab0ac6-660c-11e5-8f1e-63e27c324233.png)

@ipa-mig @ipa-srd 
did you had this before?
