### PR TITLE
cob_srvs: Adding SetOperationMode and Trigger services

### DIFF
--- a/cob_srvs/CMakeLists.txt
+++ b/cob_srvs/CMakeLists.txt
@@ -1,16 +1,19 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(cob_srvs)
 
-find_package(catkin REQUIRED COMPONENTS message_generation)
+find_package(catkin REQUIRED COMPONENTS std_msgs message_generation)
 
 add_service_files(FILES
+  Trigger.srv
   SetFloat.srv
   SetInt.srv
   SetString.srv
+  SetOperationMode.srv
 )
 
 generate_messages(
   DEPENDENCIES
+  std_msgs
 )
 
 catkin_package(

--- a/cob_srvs/package.xml
+++ b/cob_srvs/package.xml
@@ -14,6 +14,7 @@
   <buildtool_depend>catkin</buildtool_depend>
 
   <build_depend>message_generation</build_depend>
+  <build_depend>std_msgs</build_depend>
   <exec_depend>message_runtime</exec_depend>
 
 </package>

--- a/cob_srvs/srv/SetOperationMode.srv
+++ b/cob_srvs/srv/SetOperationMode.srv
@@ -1,0 +1,4 @@
+std_msgs/String operation_mode
+---
+std_msgs/Bool success
+std_msgs/String error_message

--- a/cob_srvs/srv/Trigger.srv
+++ b/cob_srvs/srv/Trigger.srv
@@ -1,0 +1,3 @@
+---
+std_msgs/Bool success
+std_msgs/String error_message


### PR DESCRIPTION
 Adding SetOperationMode and Trigger services from older branches. Required dependency for ipa_canopen_ros package
