### PR TITLE
allow static sensorring

### DIFF
--- a/cob_description/urdf/cob4_sensorring/sensorring.transmission.xacro
+++ b/cob_description/urdf/cob4_sensorring/sensorring.transmission.xacro
@@ -3,9 +3,11 @@
 
   <xacro:include filename="$(find cob_description)/urdf/common.xacro" />
 
-  <xacro:macro name="sensorring_transmission" params="name">
+  <xacro:macro name="sensorring_transmission" params="name active">
 
-    <xacro:default_transmission jname="${name}"/>
+    <xacro:if value="${active}">
+      <xacro:default_transmission jname="${name}"/>
+    </xacro:if>
 
   </xacro:macro>
 

--- a/cob_description/urdf/cob4_sensorring/sensorring.urdf.xacro
+++ b/cob_description/urdf/cob4_sensorring/sensorring.urdf.xacro
@@ -4,7 +4,7 @@
   <xacro:include filename="$(find cob_description)/urdf/cob4_sensorring/sensorring.gazebo.xacro" />
   <xacro:include filename="$(find cob_description)/urdf/cob4_sensorring/sensorring.transmission.xacro" />
 
-  <xacro:macro name="sensorring" params="parent name *origin">
+  <xacro:macro name="sensorring" params="parent name *origin active:=false">
 
     <joint name="${name}_base_joint" type="fixed">
       <insert_block name="origin" />
@@ -28,13 +28,22 @@
       </collision>
     </link>
 
-    <joint name="${name}_joint" type="revolute">
-      <origin xyz="0 0 0" rpy="0 0 0" />
-      <parent link="${name}_base_link"/>
-      <child link="${name}_link" />
-      <axis xyz="0 0 1" />
-      <limit effort="100" lower="-6.2831" upper="6.2831" velocity="2.62"/>
-    </joint>
+    <xacro:unless value="${active}">
+      <joint name="${name}_joint" type="fixed">
+        <origin xyz="0 0 0" rpy="0 0 0" />
+        <parent link="${name}_base_link"/>
+        <child link="${name}_link" />
+      </joint>
+    </xacro:unless>
+    <xacro:if value="${active}">
+      <joint name="${name}_joint" type="revolute">
+        <origin xyz="0 0 0" rpy="0 0 0" />
+        <parent link="${name}_base_link"/>
+        <child link="${name}_link" />
+        <axis xyz="0 0 1" />
+        <limit effort="100" lower="-6.2831" upper="6.2831" velocity="2.62"/>
+      </joint>
+    </xacro:if>
 
     <link name="${name}_link">
       <xacro:default_inertial/>
@@ -59,7 +68,7 @@
 
     <!-- extensions -->
     <xacro:sensorring_gazebo name="${name}" />
-    <xacro:sensorring_transmission name="${name}" />
+    <xacro:sensorring_transmission name="${name}" active="${active}" />
 
   </xacro:macro>
 


### PR DESCRIPTION
Introducing URDF argument to make sensorring static
This is required in case the sensorring is not operable in hardware and thus is not started....however, in simulation, a controller needs to be available for revolute joints as the joint would collapse otherwise

This is required for https://github.com/ipa320/cob_robots/pull/583 in order to harmonize hardware and simulation, in particular current state of cob4-1/cob4-2 hardware state