### PR TITLE
default values for simulated sensors

### DIFF
--- a/cob_description/urdf/sensors/kinect.gazebo.xacro
+++ b/cob_description/urdf/sensors/kinect.gazebo.xacro
@@ -1,17 +1,18 @@
 <?xml version="1.0"?>
 <root xmlns:xacro="http://www.ros.org/wiki/xacro">
 
-  <xacro:macro name="cob_kinect_gazebo_v0" params="name ros_topic">
+  <xacro:macro name="cob_kinect_gazebo_v0" params="name ros_topic
+                                                   update_rate:=20 data_skip:=0 height:=480 width:=640">
     <gazebo reference="${name}_frame">
       <sensor type="depth" name="${name}_frame_sensor">
         <always_on>true</always_on>
-        <update_rate>20.0</update_rate>
+        <update_rate>${update_rate/(data_skip+1)}</update_rate>
         <camera>
           <horizontal_fov>${62.0*M_PI/180.0}</horizontal_fov>
           <image>
             <format>R8G8B8</format>
-            <width>640</width>
-            <height>480</height>
+            <width>${height}</width>
+            <height>${width}</height>
           </image>
           <clip>
             <near>0.1</near>
@@ -24,7 +25,7 @@
           </noise>
         </camera>
         <plugin name="${name}_controller" filename="libgazebo_ros_openni_kinect.so">
-          <updateRate>20.0</updateRate>
+          <updateRate>${update_rate/(data_skip+1)}</updateRate>
           <cameraName>${ros_topic}</cameraName>
           <frameName>${name}_link</frameName>
           <imageTopicName>rgb/image_raw</imageTopicName>

--- a/cob_description/urdf/sensors/kinect.urdf.xacro
+++ b/cob_description/urdf/sensors/kinect.urdf.xacro
@@ -3,7 +3,7 @@
 
   <xacro:include filename="$(find cob_description)/urdf/sensors/kinect.gazebo.xacro" />
 
-  <xacro:macro name="cob_kinect_v0" params="name parent *origin ros_topic">
+  <xacro:macro name="cob_kinect_v0" params="name parent *origin ros_topic update_rate:=20 data_skip:=0 height:=480 width:=640">
     <joint name="${name}_joint" type="fixed">
       <xacro:insert_block name="origin" />
       <parent link="${parent}"/>
@@ -38,7 +38,11 @@
     <link name="${name}_frame"/>
 
     <!-- extensions -->
-    <xacro:cob_kinect_gazebo_v0 name="${name}" ros_topic="${ros_topic}" />
+    <xacro:cob_kinect_gazebo_v0 name="${name}" ros_topic="${ros_topic}"
+    									       update_rate="${update_rate}"
+    									       data_skip="${data_skip}"
+									           height="${height}"
+									           width="${width}"/>
   </xacro:macro>
 
 </root>

--- a/cob_description/urdf/sensors/realsense.gazebo.xacro
+++ b/cob_description/urdf/sensors/realsense.gazebo.xacro
@@ -1,17 +1,20 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
 
-  <xacro:macro name="realsense_gazebo" params="name ros_topic">
+  <!-- use default values of realsense_camera/r200_nodelet_rgbd -->
+  <xacro:macro name="realsense_gazebo" params="name ros_topic
+                                               depth_fps:=30.0 depth_height:=360 depth_width:=480
+                                               color_fps:=30.0 color_height:=480 color_width:=640" >
     <gazebo reference="${name}_link">
       <sensor type="depth" name="${name}_depth_frame">
         <always_on>true</always_on>
-        <update_rate>25.0</update_rate>
+        <update_rate>${color_fps}</update_rate>
         <camera>
           <horizontal_fov>${74.0*M_PI/180.0}</horizontal_fov>
           <image>
             <format>R8G8B8</format>
-            <width>320</width>
-            <height>240</height>
+            <width>${color_width}</width>
+            <height>${color_height}</height>
           </image>
           <clip>
             <near>0.15</near>
@@ -24,7 +27,7 @@
           </noise>
         </camera>
         <plugin name="${name}_frame_controller" filename="libgazebo_ros_openni_kinect.so">
-          <updateRate>25.0</updateRate>
+          <updateRate>${color_fps}</updateRate>
           <cameraName>${ros_topic}</cameraName>
           <frameName>${name}_rgb_optical_frame</frameName>
           <imageTopicName>rgb/image_raw</imageTopicName>

--- a/cob_description/urdf/sensors/usb_cam.gazebo.xacro
+++ b/cob_description/urdf/sensors/usb_cam.gazebo.xacro
@@ -1,17 +1,18 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
 
-  <xacro:macro name="usb_cam_gazebo" params="name ros_topic">
+  <!-- at 2048x1536 3.6hz is maximum on hw -->
+  <xacro:macro name="usb_cam_gazebo" params="name ros_topic update_rate:=3.5 height:=1536 width:=2048" >
     <gazebo reference="${name}_frame">
 
     <sensor type="camera" name="${name}">
-      <update_rate>5</update_rate>
+      <update_rate>${update_rate}</update_rate>
       <camera name="${name}">
-        <horizontal_fov>2.97</horizontal_fov>
+        <horizontal_fov>${170.0*M_PI/180.0}</horizontal_fov>
         <image>
-          <width>2048</width>
-          <height>1536</height>
           <format>R8G8B8</format>
+          <width>${width}</width>
+          <height>${height}</height>
         </image>
         <clip>
           <near>0.02</near>
@@ -25,7 +26,7 @@
       </camera>
       <plugin name="camera_controller" filename="libgazebo_ros_camera.so">
         <alwaysOn>true</alwaysOn>
-        <updateRate>0.0</updateRate>
+        <updateRate>${update_rate}</updateRate>
         <cameraName>${ros_topic}</cameraName>
         <imageTopicName>image_raw</imageTopicName>
         <cameraInfoTopicName>camera_info</cameraInfoTopicName>

--- a/cob_description/urdf/sensors/usb_cam.urdf.xacro
+++ b/cob_description/urdf/sensors/usb_cam.urdf.xacro
@@ -3,7 +3,7 @@
 
   <xacro:include filename="$(find cob_description)/urdf/sensors/usb_cam.gazebo.xacro" />
 
-  <xacro:macro name="usb_cam" params="name parent ros_topic *origin">
+  <xacro:macro name="usb_cam" params="name parent *origin ros_topic update_rate height width">
     <joint name="${name}_joint" type="fixed">
       <xacro:insert_block name="origin" />
       <parent link="${parent}"/>
@@ -38,7 +38,10 @@
 
     <link name="${name}_frame"/>
     <!-- extensions -->
-    <xacro:usb_cam_gazebo name="${name}" ros_topic="${ros_topic}" />
+    <xacro:usb_cam_gazebo name="${name}" ros_topic="${ros_topic}"
+									     update_rate="${update_rate}"
+									     height="${height}"
+									     width="${width}"/>
   </xacro:macro>
 
 </robot>


### PR DESCRIPTION
adjust gazebo plugins for (camera) sensors according to config used on hardware, e.g. [default values realsense](https://github.com/intel-ros/realsense/blob/indigo-devel/realsense_camera/launch/r200_nodelet_rgbd.launch#L16-L22)