### PR TITLE
fix the wheel radius to meet with the actual hardware radii

### DIFF
--- a/raw_description/urdf/base_long/base.urdf.xacro
+++ b/raw_description/urdf/base_long/base.urdf.xacro
@@ -13,7 +13,7 @@
   <xacro:property name="caster_offset_y_br" value="-0.184" />
   <xacro:property name="caster_offset_y_fl" value="0.184" />
   <xacro:property name="caster_offset_y_fr" value="-0.134" />
-  <xacro:property name="caster_offset_z" value="0.09" />
+  <xacro:property name="caster_offset_z" value="0.08" />
 
   <xacro:property name="battery_offset_x_f" value="0.141" />
   <xacro:property name="battery_offset_x_r" value="0.139" />

--- a/raw_description/urdf/base_short/base.urdf.xacro
+++ b/raw_description/urdf/base_short/base.urdf.xacro
@@ -14,7 +14,7 @@
   <xacro:property name="caster_offset_y_br" value="-0.184" />
   <xacro:property name="caster_offset_y_fl" value="0.184" />
   <xacro:property name="caster_offset_y_fr" value="-0.134" />
-  <xacro:property name="caster_offset_z" value="0.09" />
+  <xacro:property name="caster_offset_z" value="0.08" />
 
   <xacro:property name="battery_offset_x" value="0.0" />
   <xacro:property name="battery_offset_y" value="-0.008" />


### PR DESCRIPTION
The urdf conflicted with the parameter set for the base controller:
https://github.com/ipa320/cob_robots/blob/indigo_dev/cob_hardware_config/robots/common/raw3_base_controller.yaml#L49

after a check with @ipa-taj the wheels have 160mm diameter.

The issue showed when comparing the commanded twist with the odometry

@ipa-mdl for reference
