### PR TITLE
Replace vacuum gripper collision mesh with bounding box

### DIFF
--- a/raw_description/urdf/vacuum_gripper/gripper.urdf.xacro
+++ b/raw_description/urdf/vacuum_gripper/gripper.urdf.xacro
@@ -38,9 +38,9 @@
             </material>
         </visual>
         <collision>
-            <origin xyz="0 0 -0.048" rpy="0 0 0"/>
+            <origin xyz="0.01 0.04 -0.048" rpy="0 0 0"/>
             <geometry>
-                <mesh filename="package://raw_description/meshes/vacuum_gripper/vacuum_gripper.stl"/>
+                <box size="0.13 0.14 0.071"/>
             </geometry>
         </collision>
     </link>


### PR DESCRIPTION
Hi guys,

I've replaced the collision object of the vacuum gripper with a box, intead of that very detailed mesh. This should speed up computations for collision checking and everything that uses that (moveit mostly).