### PR TITLE
cob_common: fix test_urdf.py

### DIFF
--- a/cob_description/test/test_urdf.py
+++ b/cob_description/test/test_urdf.py
@@ -41,9 +41,10 @@ class TestUrdf(unittest.TestCase):
 			self.fail('file "' + file_to_test + '" not found')
 
 		# check if xacro can be converted
-		p = subprocess.Popen("`rospack find xacro`/xacro --inorder " + file_to_test + " > /tmp/test.urdf", shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+		p = subprocess.Popen("rosrun xacro xacro --inorder " + file_to_test + " > /tmp/test.urdf", shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+		(out,err) = p.communicate()
 		if p.returncode != 0 and p.returncode != None:
-			self.fail("cannot convert xacro. file: " + file_to_test + "\n" + p.stderr.read())
+			self.fail("cannot convert xacro. file: " + file_to_test + "\nOutput: " + out + "\nError: " + err)
 
 		# check if urdf is correct
 		p = subprocess.Popen("check_urdf /tmp/test.urdf", shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)


### PR DESCRIPTION
* fix check of return value from subprocess call
* use 'rosrun xacro xacro' instead of 'rospack find xacro'/xacro as this does not work in kinetic anymore and is deprecated anyways...
* clearer error output


The old version always returns successful, no matter what the input is.
Can easily be tested with e.g the following clearly wrong file...
```XML
<?xml version="1.0"?>
<robot xmlns:xacro="http://www.ros.org/wiki/xacro">

  <aro:prrty name="defect value="1 >

</robot>
```