### PR TITLE
add PositionJointInterface for fdm rotation joints

### DIFF
--- a/cob_description/urdf/drive_wheel/drive_wheel.transmission.xacro
+++ b/cob_description/urdf/drive_wheel/drive_wheel.transmission.xacro
@@ -22,6 +22,7 @@
     <transmission name="${suffix}_rotation_trans">
       <type>transmission_interface/SimpleTransmission</type>
       <joint name="${suffix}_rotation_joint" >
+        <hardwareInterface>PositionJointInterface</hardwareInterface>
         <hardwareInterface>VelocityJointInterface</hardwareInterface>
       </joint>
       <actuator name="${suffix}_rotation_motor" >


### PR DESCRIPTION
needed to use https://github.com/ipa320/cob_control/pull/140 in simulation

no effects on hardware - simulation only
backwards-compatible - because with velocity-based omni-drive controller VelocityJointInterface is used...(`cob_gazebo_ros_control`-plugin does the switching)