### PR TITLE
[WIP] allow simulate backwards driving

### DIFF
--- a/cob_description/urdf/cob4_base/base.urdf.xacro
+++ b/cob_description/urdf/cob4_base/base.urdf.xacro
@@ -96,25 +96,25 @@
 
     <!-- arrangement of the three drive_wheel modules -->
     <xacro:if value="${tricycle_mode}">
-      <xacro:drive_wheel parent="${name}_chassis_link" suffix="fl" passive="true" >
+      <xacro:drive_wheel parent="${name}_chassis_link" suffix="fl" passive="true" forward="${forward}">
         <origin xyz="${caster_offset_x/2} ${caster_offset_y} ${caster_offset_z}" rpy="0 0 0" />
       </xacro:drive_wheel>
-      <xacro:drive_wheel parent="${name}_chassis_link" suffix="b" >
+      <xacro:drive_wheel parent="${name}_chassis_link" suffix="b" forward="${forward}">
         <origin xyz="${-caster_offset_x} 0.0 ${caster_offset_z}" rpy="0 0 0" />
       </xacro:drive_wheel>
-      <xacro:drive_wheel parent="${name}_chassis_link" suffix="fr" passive="true">
+      <xacro:drive_wheel parent="${name}_chassis_link" suffix="fr" passive="true" forward="${forward}">
         <origin xyz="${caster_offset_x/2} ${-caster_offset_y} ${caster_offset_z}" rpy="0 0 0" />
       </xacro:drive_wheel>
     </xacro:if>
 
     <xacro:unless value="${tricycle_mode}">
-      <xacro:drive_wheel parent="${name}_chassis_link" suffix="fl" >
+      <xacro:drive_wheel parent="${name}_chassis_link" suffix="fl" forward="${forward}">
         <origin xyz="${caster_offset_x/2} ${caster_offset_y} ${caster_offset_z}" rpy="0 0 0" />
       </xacro:drive_wheel>
-      <xacro:drive_wheel parent="${name}_chassis_link" suffix="b" >
+      <xacro:drive_wheel parent="${name}_chassis_link" suffix="b" forward="${forward}">
         <origin xyz="${-caster_offset_x} 0.0 ${caster_offset_z}" rpy="0 0 0" />
       </xacro:drive_wheel>
-      <xacro:drive_wheel parent="${name}_chassis_link" suffix="fr" >
+      <xacro:drive_wheel parent="${name}_chassis_link" suffix="fr" forward="${forward}">
         <origin xyz="${caster_offset_x/2} ${-caster_offset_y} ${caster_offset_z}" rpy="0 0 0" />
       </xacro:drive_wheel>
     </xacro:unless>

--- a/cob_description/urdf/drive_wheel/drive_wheel.urdf.xacro
+++ b/cob_description/urdf/drive_wheel/drive_wheel.urdf.xacro
@@ -9,14 +9,19 @@
   <xacro:property name="caster_mass" value="5.9" />
   <xacro:property name="wheel_mass" value="0.44036" />
 
-  <xacro:macro name="cob_wheel" params="parent suffix reflect drive_vel:=^ passive:=false">
+  <xacro:macro name="cob_wheel" params="parent suffix reflect drive_vel:=^ passive:=false forward:=true">
 
     <xacro:if value="${passive}">
       <joint name="${parent}_${suffix}_wheel_joint" type="continuous">
         <origin xyz="0 ${reflect*caster_wheel_offset_y} 0" rpy="0 0 0" />
         <parent link="${parent}_rotation_link"/>
         <child link="${parent}_${suffix}_wheel_link"/>
-        <axis xyz="0 1 0" />
+        <xacro:if value="${forward}">
+          <axis xyz="0 1 0" />
+        </xacro:if>
+        <xacro:unless value="${forward}">
+          <axis xyz="0 -1 0" />
+        </xacro:unless>
         <safety_controller  k_velocity="10" />
         <limit effort="0.0" velocity="${drive_vel}"/>
         <dynamics damping="0.0" friction="0.0" />
@@ -27,7 +32,12 @@
         <origin xyz="0 ${reflect*caster_wheel_offset_y} 0" rpy="0 0 0" />
         <parent link="${parent}_rotation_link"/>
         <child link="${parent}_${suffix}_wheel_link"/>
-        <axis xyz="0 1 0" />
+        <xacro:if value="${forward}">
+          <axis xyz="0 1 0" />
+        </xacro:if>
+        <xacro:unless value="${forward}">
+          <axis xyz="0 -1 0" />
+        </xacro:unless>
         <safety_controller  k_velocity="10" />
         <limit effort="100" velocity="${drive_vel}"/>
         <dynamics damping="0.0" friction="0.0" />
@@ -111,13 +121,13 @@
   </xacro:macro>
 
 
-  <xacro:macro name="drive_wheel" params="*origin parent suffix drive_vel:=^|100 steer_vel:=^|100 passive:=false">
+  <xacro:macro name="drive_wheel" params="*origin parent suffix drive_vel:=^|100 steer_vel:=^|100 passive:=false forward:=true">
 
     <xacro:cob_caster_hub parent="${parent}" suffix="${suffix}_caster" passive="${passive}" >
       <xacro:insert_block name="origin" />
     </xacro:cob_caster_hub>
 
-    <xacro:cob_wheel parent="${suffix}_caster" suffix="r" reflect="-1"  passive="${passive}" />
+    <xacro:cob_wheel parent="${suffix}_caster" suffix="r" reflect="-1"  passive="${passive}" forward="${forward}" />
 
     <!-- extensions -->
     <xacro:cob_caster_gazebo suffix="${suffix}" />


### PR DESCRIPTION
ref https://github.com/ipa320/cob_common/pull/261

bases that drive backwards cannot be simulated properly - they still drive forward!
on the hardware, this is fixed by adjustint the `homing offset` in the `base_driver.yaml`/`base_calibration.yaml´ - however, this yaml is not considered during simulation

I tried to achieve the homing offset via urdf - for both simulation and hw - so that the modification in the yaml is not needed anymore...but I haven't managed it yet....
the current solution still works for both simulation and hw (still modification of yaml needed), because the joint rotation axis does not affect the real hardware behavior...

Still, I'm not yet satisfied 100%

also, the tricycle simulation is very bouncy and inaccurate...