### PR TITLE
add explicit power_state.connected

### DIFF
--- a/cob_msgs/msg/PowerState.msg
+++ b/cob_msgs/msg/PowerState.msg
@@ -5,6 +5,7 @@ float64 current                     # [A]
 float64 power_consumption           # [W] can only be calculated if not charging
 float64 remaining_capacity          # [Ah]
 float64 relative_remaining_capacity # [0..100] percent of maximum capacity (parameter max_capacity)
-bool charging                       # flag if robot is connected to external power or not
+bool connected                      # flag if robot is connected to external power or not (charging station or external charger)
+bool charging                       # flag if robot is charging (energy flow into battery)
 float64 time_remaining              # [h] estimated time to empty or fully charged
 float64 temperature                 # [Celsius] temperature of the battery


### PR DESCRIPTION
ref https://github.com/mojin-robotics/cob4/issues/2496

This explicitly adds an additional bool flag for the connection status to the charger.

Up to now we used to interpret `power_state.charging` as plugged to charging station or plugged to external charger by evaluating the `power_state.current` with magic thresholds. With the new field `power_state.connected` we can express better that we are connected to the charger but not charging (because battery might be full already).