### PR TITLE
Remove actionlib_msgs dependency

### DIFF
--- a/cob_actions/CMakeLists.txt
+++ b/cob_actions/CMakeLists.txt
@@ -19,7 +19,6 @@ find_package(ament_cmake REQUIRED)
 find_package(rosidl_default_generators REQUIRED)
 find_package(builtin_interfaces REQUIRED)
 find_package(action_msgs REQUIRED)
-find_package(actionlib_msgs REQUIRED)
 find_package(geometry_msgs REQUIRED)
 
 set(action_files
@@ -32,7 +31,7 @@ set(action_files
 
 rosidl_generate_interfaces(${PROJECT_NAME}
   ${action_files}
-  DEPENDENCIES builtin_interfaces action_msgs actionlib_msgs geometry_msgs
+  DEPENDENCIES builtin_interfaces action_msgs geometry_msgs
   ADD_LINTER_TESTS
 )
 

--- a/cob_actions/package.xml
+++ b/cob_actions/package.xml
@@ -17,7 +17,6 @@
 
   <depend>builtin_interfaces</depend>
   <depend>action_msgs</depend>
-  <depend>actionlib_msgs</depend>
   <depend>geometry_msgs</depend>
 
   <exec_depend>rosidl_default_runtime</exec_depend>


### PR DESCRIPTION
`actionlib_msgs` is deprecated long time ago, at least since [foxy](https://github.com/ros2/common_interfaces/tree/foxy/actionlib_msgs) This PR remove `actionlib_msgs` because is never used. 

Related with https://github.com/ros2/common_interfaces/pull/280