### PR TITLE
[foxy] Bump actions/checkout from 4 to 5

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,7 +29,7 @@ jobs:
           - { ROS_DISTRO: foxy }
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: true
           lfs: true


### PR DESCRIPTION
`foxy` companion for
- https://github.com/4am-robotics/cob_common/pull/319
